### PR TITLE
export a port configuration and full ListTables response

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -123,12 +123,7 @@ var ddb = function(spec, my) {
       data.Limit = options.limit;
     if(options.exclusiveStartTableName)
       data.ExclusiveStartTableName = options.exclusiveStartTableName;
-    execute('ListTables', data, function(err, res) {
-        if(err) { cb(err) }
-        else {
-          cb(null, res.TableNames);
-        }
-      });
+    execute('ListTables', data, cb);
   };
 
 


### PR DESCRIPTION
Port is mostly for a local dev server (which I'm working on in a separate project).

The complete response of ListTables should be returned, that way if the user specified Limit and gets back a LastEvaluatedTableName, they can use the API as it was intended.
