### PR TITLE
Fixed issue where PutItem would not work when attribute values contained utf-8 chars. 

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -408,7 +408,7 @@ var ddb = function(spec, my) {
                      rqBody);
           
           var sha = crypto.createHash('sha256');
-          sha.update(sts);
+          sha.update(new Buffer(sts,'utf8'));
           var hmac = crypto.createHmac('sha256', my.access.secretAccessKey);
           hmac.update(sha.digest());                        
 
@@ -425,7 +425,7 @@ var ddb = function(spec, my) {
                           'X-amzn-authorization' : auth,
                           'date': dtStr,
                           'content-type': 'application/x-amz-json-1.0',
-                          'content-length': rqBody.length };
+                          'content-length': Buffer.byteLength(rqBody,'utf8') };
 
           var options = { host: my.endpoint,
                           port: my.port,


### PR DESCRIPTION
Whenever I had Korean or Chinese in an attribute value, AWS would return a 400. It turns out that you needed to return the actual byte count, and not the string length via Buffer.byteLength(reqBody). Also, the sha.update function needed a UTF-8 Buffer of the sts to correctly calculate the signature. The crypto functions work with both Buffers and Strings, so sending the buffer will give it the correct length of the UTF-8 bytes.
