### PR TITLE
Entropy in exponential falloff retry and get new STS auth token earlier

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -961,7 +961,7 @@ var ddb = function(spec, my) {
    */
   auth = function(cb) {
     // auth if necessary and always async
-    if(my.access && my.access.expiration.getTime() < ((new Date).getTime() + 2000)) {
+    if(my.access && my.access.expiration.getTime() < ((new Date).getTime() + 60000)) {
       //console.log('CLEAR AUTH: ' + my.access.expiration + ' ' + new Date);
       delete my.access;
       my.inAuth = false;
@@ -1015,7 +1015,7 @@ var ddb = function(spec, my) {
                             expiration: new Date(e_r[1]) };
 
               //console.log('AUTH OK: ' + require('util').inspect(my.access) + '\n' +
-              //            ((my.access.expiration - new Date) - 2000));
+              //            ((my.access.expiration - new Date) - 60000));
 
               my.inAuth = false;
               that.emit('auth');


### PR DESCRIPTION
Here's two patches which we've found helpful in our environment:

1) Add random entropy to the exponential falloff. This has helped us to handle more extreme load with dynamodb as the retries will distribute into the future, smoothing the peak loads.

2) Request new STS auth token one minute earlier instead of the original two seconds. We have found that sometimes STS request might take longer than two seconds (rarely, but it happens) and also that an EC2 instance clock might be easily drift more than two seconds, resulting in "The security token included in the request is expired". 
