### PR TITLE
Fix calling callback twice on error.

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -892,6 +892,10 @@ var ddb = function(spec, my) {
                     body += chunk;
                   });
                 res.on('end', function() {
+                    if (!cb) {
+                      // Do not call callback if it's already been called in the error handler.
+                      return;
+                    }
                     try {
                       var json = JSON.parse(body);
                     }
@@ -917,6 +921,7 @@ var ddb = function(spec, my) {
 
             req.on('error', function(err) {
                 cb(err);
+                cb = undefined; // Clear callback so we do not call it twice
               });
 
             req.write(rqBody);


### PR DESCRIPTION
"cb" was getting called twice if the request emits an "error" event (and then later an "end" event).

Seems to be happening relatively frequently for us recently, possibly after upgrading to node 0.8.x (error event we got was from the node http parser, "HPE_INVALID_CHUNK_SIZE").
