### PR TITLE
Add object types from db for list and map

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -812,6 +812,14 @@ var ddb = function(spec, my) {
             for(var j = 0; j < ddb[i]['NS'].length; j ++) {
               res[i][j] = parseFloat(ddb[i]['NS'][j]);
             }
+          } else if(ddb[i]['L']) {
+            res[i] = [];
+            ddb[i]['L'].forEach(function(item) {
+              res[i].push(objFromDDB(item));
+            });
+          // or if 'M'
+          } else if(typeof ddb[i] === 'object') {
+            return objFromDDB(ddb[i]);
           }
           else
             throw new Error('Non Compatible Field [not "S"|"N"|"NS"|"SS"]: ' + i);


### PR DESCRIPTION
Allows users to now use maps and lists from dynamodb tables.
- Check for "L", iterates over and appends to array for key
- Check for "object" after everything is said and done and appends a new map from
  objFromDDB to key
