### PR TITLE
Fixing Map element bug.

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -44,7 +44,7 @@ var ddb = function(spec, my) {
   my.port = spec.port || 80;
   my.agent = spec.agent;
 
-  my.retries = spec.retries || 3; 
+  my.retries = spec.retries || 3;
 
   // Use already obtained temporary session credentials
   if(spec.sessionToken && spec.sessionExpires) {
@@ -53,7 +53,7 @@ var ddb = function(spec, my) {
                   accessKeyId: spec.accessKeyId,
                   expiration: spec.sessionExpires };
   }
-  
+
   my.inAuth = false;
   my.consumedCapacity = 0;
   my.schemaTypes = { number: 'N',
@@ -433,7 +433,7 @@ var ddb = function(spec, my) {
   /**
    * An object representing a table query, or an array of such objects
    * { 'table': { keys: [1, 2, 3], attributesToGet: ['user', 'status'] } }
-   *           or keys: [['id', 'range'], ['id2', 'range2']] 
+   *           or keys: [['id', 'range'], ['id2', 'range2']]
    * @param cb callback(err, tables) err is set if an error occured
    */
   batchGetItem = function(request, cb) {
@@ -443,7 +443,7 @@ var ddb = function(spec, my) {
       for(var table in request) {
         if(request.hasOwnProperty(table)) {
           var parts = Array.isArray(request[table]) ? request[table] : [request[table]];
-          
+
           for(var i = 0; i < parts.length; ++i) {
             var part = parts[i];
             var tableData = {Keys: []};
@@ -524,17 +524,17 @@ var ddb = function(spec, my) {
           }
         }
       }
-   
+
       for(var table in deleteRequest) {
         if(deleteRequest.hasOwnProperty(table)) {
           var parts = (Array.isArray(deleteRequest[table]) ? deleteRequest[table] : [deleteRequest[table]]);
-          
+
           for(var i = 0; i < parts.length; i++) {
             var part = parts[i];
             var hasRange = Array.isArray(part);
-            
+
             var keyData = hasRange ? {"HashKeyElement": scToDDB(part[0]), "RangeKeyElement": scToDDB(part[1])} : {"HashKeyElement": scToDDB(part)};
-            
+
             data.RequestItems[table] = data.RequestItems[table] || [];
             data.RequestItems[table].push( { "DeleteRequest": { "Key" : keyData }} );
           }
@@ -560,15 +560,15 @@ var ddb = function(spec, my) {
       });
     }
     catch(err) {
-      cb(err) 
-    }     
+      cb(err)
+    }
   };
 
   /**
    * returns a set of Attributes for an item that matches the query
    * @param table the tableName
    * @param hash the hashKey
-   * @param options {attributesToGet, limit, consistentRead, count, 
+   * @param options {attributesToGet, limit, consistentRead, count,
    *                 rangeKeyCondition, scanIndexForward, exclusiveStartKey, indexName}
    * @param cb callback(err, tables) err is set if an error occured
    */
@@ -611,7 +611,7 @@ var ddb = function(spec, my) {
       if(options.exclusiveStartKey && options.exclusiveStartKey.hash) {
         data.ExclusiveStartKey = { HashKeyElement: scToDDB(options.exclusiveStartKey.hash) };
         if(options.exclusiveStartKey.range)
-          data.ExclusiveStartKey.RangeKeyElement = scToDDB(options.exclusiveStartKey.range);      
+          data.ExclusiveStartKey.RangeKeyElement = scToDDB(options.exclusiveStartKey.range);
       }
       if(options.indexName) {
         data.IndexName = options.indexName;
@@ -670,7 +670,7 @@ var ddb = function(spec, my) {
       if(options.exclusiveStartKey && options.exclusiveStartKey.hash) {
         data.ExclusiveStartKey = { HashKeyElement: scToDDB(options.exclusiveStartKey.hash) };
         if(options.exclusiveStartKey.range)
-          data.ExclusiveStartKey.RangeKeyElement = scToDDB(options.exclusiveStartKey.range);      
+          data.ExclusiveStartKey.RangeKeyElement = scToDDB(options.exclusiveStartKey.range);
       }
       if(options.filter) {
         data.ScanFilter = {}
@@ -710,7 +710,7 @@ var ddb = function(spec, my) {
           var r = { count: res.Count,
                     items: [],
                     lastEvaluatedKey: {},
-                    scannedCount: res.ScannedCount };          
+                    scannedCount: res.ScannedCount };
           try {
             if(Array.isArray(res.Items)) {
               r.items = arrFromDDB(res.Items);
@@ -729,13 +729,13 @@ var ddb = function(spec, my) {
         }
       });
   };
-  
+
 
 
   //-- INTERNALS --//
 
   /**
-   * converts a JSON object (dictionary of values) to an amazon DynamoDB 
+   * converts a JSON object (dictionary of values) to an amazon DynamoDB
    * compatible JSON object
    * @param json the JSON object
    * @throws an error if input object is not compatible
@@ -755,7 +755,7 @@ var ddb = function(spec, my) {
       return json;
   };
 
-  
+
   /**
    * converts a string, string array, number or number array (scalar)
    * JSON object to an amazon DynamoDB compatible JSON object
@@ -784,7 +784,7 @@ var ddb = function(spec, my) {
         }
       }
       return isSS ? {"SS": arr} : {"NS": arr};
-    }     
+    }
     throw new Error('Non Compatible Field [not string|number|string array|number array]: ' + value);
   }
 
@@ -819,7 +819,7 @@ var ddb = function(spec, my) {
             });
           // or if 'M'
           } else if(typeof ddb[i] === 'object') {
-            return objFromDDB(ddb[i]);
+            res[i] = objFromDDB(ddb[i]['M']);
           }
           else
             throw new Error('Non Compatible Field [not "S"|"N"|"NS"|"SS"]: ' + i);


### PR DESCRIPTION
- Currently if your dynamo db has a Map property only that property will be returned during a scan. The change I am proposing fixes the issue and returns the full object, as including properly parsed map.

In the existing code, if map is encountered only content of the map is returned. While what should happen, map should be parsed and added to the remaining elements. 
- Removing blank spaces at the end of lines.
