### PR TITLE
Fixed critical setTimeout bug affecting Linux node v0.10.30

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -961,7 +961,7 @@ var ddb = function(spec, my) {
                   else if(c <= my.retries && c <= 10) {
                     setTimeout(function() {
                       retry(c + 1);
-                    }, Math.pow(2, c-1) * (25 * (Math.random() + 1)));
+                    }, Math.pow(2, c-1) * Math.floor(25 * (Math.random() + 1)));
                   }
                   else
                     cb(err);


### PR DESCRIPTION
Non-integer setTimeout causing 100% cpu lockup on Linux with node 0.10.30.

See here for node issue https://github.com/joyent/node/issues/8181